### PR TITLE
[Feature]  #16 - 장바구니 뷰 UI (상단, 하단) 를 구현했습니다.

### DIFF
--- a/Kurly/Kurly.xcodeproj/project.pbxproj
+++ b/Kurly/Kurly.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		17A870DA2B08A6E200D5162C /* UITextView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A870D92B08A6E200D5162C /* UITextView+.swift */; };
 		17A870DC2B08A6F700D5162C /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A870DB2B08A6F700D5162C /* UIView+.swift */; };
 		17A870DE2B08A70F00D5162C /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A870DD2B08A70F00D5162C /* UIViewController+.swift */; };
+		3F52DDCC2B0B531E00BD216E /* CartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F52DDCB2B0B531E00BD216E /* CartViewController.swift */; };
+		3F52DDCE2B0B53B200BD216E /* CartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F52DDCD2B0B53B200BD216E /* CartView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -123,6 +125,8 @@
 		17A870D92B08A6E200D5162C /* UITextView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+.swift"; sourceTree = "<group>"; };
 		17A870DB2B08A6F700D5162C /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		17A870DD2B08A70F00D5162C /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
+		3F52DDCB2B0B531E00BD216E /* CartViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartViewController.swift; sourceTree = "<group>"; };
+		3F52DDCD2B0B53B200BD216E /* CartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -324,6 +328,7 @@
 		17A8707A2B08631200D5162C /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				3F52DDC82B0B52B000BD216E /* Cart */,
 				09EAE9932B0B3BFE0079CAC4 /* AfterAddCart */,
 				09EAE9842B0B04C90079CAC4 /* AddCart */,
 				09BA86972B0A3C5900BF85D9 /* Detail */,
@@ -489,6 +494,31 @@
 			path = Base;
 			sourceTree = "<group>";
 		};
+		3F52DDC82B0B52B000BD216E /* Cart */ = {
+			isa = PBXGroup;
+			children = (
+				3F52DDC92B0B52D900BD216E /* Views */,
+				3F52DDCA2B0B52E000BD216E /* ViewControllers */,
+			);
+			path = Cart;
+			sourceTree = "<group>";
+		};
+		3F52DDC92B0B52D900BD216E /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				3F52DDCD2B0B53B200BD216E /* CartView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		3F52DDCA2B0B52E000BD216E /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				3F52DDCB2B0B531E00BD216E /* CartViewController.swift */,
+			);
+			path = ViewControllers;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -602,6 +632,8 @@
 				17A870852B0863A600D5162C /* Protocols.swift in Sources */,
 				17A870DA2B08A6E200D5162C /* UITextView+.swift in Sources */,
 				09BA86B12B0A4DB100BF85D9 /* TabBarCollectionViewCell.swift in Sources */,
+				3F52DDCC2B0B531E00BD216E /* CartViewController.swift in Sources */,
+				3F52DDCE2B0B53B200BD216E /* CartView.swift in Sources */,
 				17A8709B2B0864BB00D5162C /* DataModel.swift in Sources */,
 				17A870932B08649300D5162C /* View.swift in Sources */,
 				09DE08382B05B70100D7DF3D /* SceneDelegate.swift in Sources */,

--- a/Kurly/Kurly/Presentation/Cart/ViewControllers/CartViewController.swift
+++ b/Kurly/Kurly/Presentation/Cart/ViewControllers/CartViewController.swift
@@ -1,0 +1,44 @@
+//
+//  CartViewController.swift
+//  Kurly
+//
+//  Created by ParkJunHyuk on 2023/11/20.
+//
+
+import UIKit
+
+import SnapKit
+
+final class CartViewController: BaseViewController {
+
+    private let cartView = CartView()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setTarget()
+    }
+    
+    override func loadView() {
+        self.view = cartView
+    }
+}
+
+extension CartViewController {
+    
+    private func setTarget(){
+        cartView.navigationBar.closeButton.addTarget(self, action: #selector(tapBackButton), for: .touchUpInside)
+        
+        cartView.bottomCTAButton.addTarget(self, action: #selector(tapOrderButton), for: .touchUpInside)
+    }
+}
+
+extension CartViewController {
+    
+    @objc func tapBackButton() {
+        self.dismiss(animated: true)
+    }
+    
+    @objc func tapOrderButton() {
+        print("주문하기!")
+    }
+}

--- a/Kurly/Kurly/Presentation/Cart/Views/CartView.swift
+++ b/Kurly/Kurly/Presentation/Cart/Views/CartView.swift
@@ -1,0 +1,44 @@
+//
+//  CartView.swift
+//  Kurly
+//
+//  Created by ParkJunHyuk on 2023/11/20.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class CartView: BaseView {
+    
+    let navigationBar = CustomNavigationBar(type: .closeButton)
+    let bottomCTAButton = BottomCTAButton(type: .order)
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setUI() {
+        self.backgroundColor = .white
+    }
+    
+    override func setLayout() {
+        self.addSubviews(navigationBar, bottomCTAButton)
+
+        navigationBar.snp.makeConstraints {
+            $0.top.equalTo(self.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
+        }
+        
+        bottomCTAButton.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.bottom.equalTo(self.safeAreaLayoutGuide)
+        }
+    }
+}

--- a/Kurly/Kurly/Presentation/Common/UIComponents/CustomNavigationBar.swift
+++ b/Kurly/Kurly/Presentation/Common/UIComponents/CustomNavigationBar.swift
@@ -31,7 +31,7 @@ final class CustomNavigationBar: UIView {
     
     private lazy var titleLabel = UILabel()
     private lazy var backButton = UIButton()
-    private lazy var closeButton = UIButton()
+    lazy var closeButton = UIButton()
     private lazy var cartButton = UIButton()
     
     
@@ -95,7 +95,7 @@ extension CustomNavigationBar {
         }
         
         closeButton.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(9)
+            $0.leading.equalToSuperview().inset(9)
             $0.centerY.equalToSuperview()
             $0.size.equalTo(36)
         }


### PR DESCRIPTION
## 🍧 작업한 내용

<!-- 작업하게 된 배경을 간단히 적어주세요! -->
- BottomCTAButton 과 CustomNavigationBar 을 재사용하여 구현
- CustomNavigationBar - closeButton type 의 경우 closeButton 의 제약 조건을 trailing 에서 leading 으로 변경
- CustomNavigationBar - closeButton 의 private 접근 제한자 제거

## 🚨 참고 사항

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 장바구니 뷰의 하단 버튼은 선택한 물품의 개수를 보여주게 되는데 모든 화면이 구현이 끝나면 진행하도록 하겠습니다!

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| PNG | <img src = "https://github.com/DO-SOPT-CDS-APP-7/Kurly-iOS/assets/45564605/a161c584-9ec3-486f-b7a3-2dba04769708" width ="250">|

## 😈 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #16 
