### PR TITLE
[Feature] #31 - 상세보기 뷰 세 번째 섹션 구현하였습니다.

### DIFF
--- a/Kurly/Kurly.xcodeproj/project.pbxproj
+++ b/Kurly/Kurly.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		178336002B0B61E3000DF127 /* FirstSectionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178335FF2B0B61E2000DF127 /* FirstSectionCollectionViewCell.swift */; };
 		178336022B0B6832000DF127 /* DetailProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178336012B0B6832000DF127 /* DetailProduct.swift */; };
 		178336062B0E2159000DF127 /* SecondSectionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178336052B0E2159000DF127 /* SecondSectionCollectionViewCell.swift */; };
+		178336082B0E5790000DF127 /* SectionThridHorizontalCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178336072B0E5790000DF127 /* SectionThridHorizontalCollectionViewCell.swift */; };
 		17A870852B0863A600D5162C /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A870842B0863A600D5162C /* Protocols.swift */; };
 		17A870932B08649300D5162C /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A870922B08649300D5162C /* View.swift */; };
 		17A870952B08649D00D5162C /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A870942B08649D00D5162C /* Models.swift */; };
@@ -79,10 +80,7 @@
 		F15DD1E12B0C9CAB00984E6D /* RecommendCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15DD1E02B0C9CAB00984E6D /* RecommendCollectionViewCell.swift */; };
 		F15DD1E32B0CBBB800984E6D /* RecommendHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15DD1E22B0CBBB800984E6D /* RecommendHeaderView.swift */; };
 		F15DD1E52B0CD37E00984E6D /* RecommendFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15DD1E42B0CD37E00984E6D /* RecommendFooterView.swift */; };
-
-
 		F15DD1E82B0DD7D100984E6D /* RecommendModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15DD1E72B0DD7D100984E6D /* RecommendModel.swift */; };
-
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -115,6 +113,7 @@
 		178335FF2B0B61E2000DF127 /* FirstSectionCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstSectionCollectionViewCell.swift; sourceTree = "<group>"; };
 		178336012B0B6832000DF127 /* DetailProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailProduct.swift; sourceTree = "<group>"; };
 		178336052B0E2159000DF127 /* SecondSectionCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondSectionCollectionViewCell.swift; sourceTree = "<group>"; };
+		178336072B0E5790000DF127 /* SectionThridHorizontalCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionThridHorizontalCollectionViewCell.swift; sourceTree = "<group>"; };
 		17A870842B0863A600D5162C /* Protocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocols.swift; sourceTree = "<group>"; };
 		17A870922B08649300D5162C /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
 		17A870942B08649D00D5162C /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
@@ -157,10 +156,7 @@
 		F15DD1E02B0C9CAB00984E6D /* RecommendCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendCollectionViewCell.swift; sourceTree = "<group>"; };
 		F15DD1E22B0CBBB800984E6D /* RecommendHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendHeaderView.swift; sourceTree = "<group>"; };
 		F15DD1E42B0CD37E00984E6D /* RecommendFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendFooterView.swift; sourceTree = "<group>"; };
-
-
 		F15DD1E72B0DD7D100984E6D /* RecommendModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendModel.swift; sourceTree = "<group>"; };
-
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -336,6 +332,7 @@
 				178335FD2B0B4DA1000DF127 /* DetailView.swift */,
 				178335FF2B0B61E2000DF127 /* FirstSectionCollectionViewCell.swift */,
 				178336052B0E2159000DF127 /* SecondSectionCollectionViewCell.swift */,
+				178336072B0E5790000DF127 /* SectionThridHorizontalCollectionViewCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -774,6 +771,7 @@
 				3F52DDCC2B0B531E00BD216E /* CartViewController.swift in Sources */,
 				3F52DDCE2B0B53B200BD216E /* CartView.swift in Sources */,
 				17A8709B2B0864BB00D5162C /* DataModel.swift in Sources */,
+				178336082B0E5790000DF127 /* SectionThridHorizontalCollectionViewCell.swift in Sources */,
 				17A870932B08649300D5162C /* View.swift in Sources */,
 				09DE08382B05B70100D7DF3D /* SceneDelegate.swift in Sources */,
 				17A870972B0864A600D5162C /* Cell.swift in Sources */,

--- a/Kurly/Kurly.xcodeproj/project.pbxproj
+++ b/Kurly/Kurly.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 		178336002B0B61E3000DF127 /* FirstSectionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178335FF2B0B61E2000DF127 /* FirstSectionCollectionViewCell.swift */; };
 		178336022B0B6832000DF127 /* DetailProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178336012B0B6832000DF127 /* DetailProduct.swift */; };
 		178336062B0E2159000DF127 /* SecondSectionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178336052B0E2159000DF127 /* SecondSectionCollectionViewCell.swift */; };
-		178336082B0E5790000DF127 /* SectionThridHorizontalCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178336072B0E5790000DF127 /* SectionThridHorizontalCollectionViewCell.swift */; };
+		178336082B0E5790000DF127 /* ThridSectionHorizontalCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178336072B0E5790000DF127 /* ThridSectionHorizontalCollectionViewCell.swift */; };
 		17A870852B0863A600D5162C /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A870842B0863A600D5162C /* Protocols.swift */; };
 		17A870932B08649300D5162C /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A870922B08649300D5162C /* View.swift */; };
 		17A870952B08649D00D5162C /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A870942B08649D00D5162C /* Models.swift */; };
@@ -113,7 +113,7 @@
 		178335FF2B0B61E2000DF127 /* FirstSectionCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstSectionCollectionViewCell.swift; sourceTree = "<group>"; };
 		178336012B0B6832000DF127 /* DetailProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailProduct.swift; sourceTree = "<group>"; };
 		178336052B0E2159000DF127 /* SecondSectionCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondSectionCollectionViewCell.swift; sourceTree = "<group>"; };
-		178336072B0E5790000DF127 /* SectionThridHorizontalCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionThridHorizontalCollectionViewCell.swift; sourceTree = "<group>"; };
+		178336072B0E5790000DF127 /* ThridSectionHorizontalCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThridSectionHorizontalCollectionViewCell.swift; sourceTree = "<group>"; };
 		17A870842B0863A600D5162C /* Protocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocols.swift; sourceTree = "<group>"; };
 		17A870922B08649300D5162C /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
 		17A870942B08649D00D5162C /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
@@ -332,7 +332,7 @@
 				178335FD2B0B4DA1000DF127 /* DetailView.swift */,
 				178335FF2B0B61E2000DF127 /* FirstSectionCollectionViewCell.swift */,
 				178336052B0E2159000DF127 /* SecondSectionCollectionViewCell.swift */,
-				178336072B0E5790000DF127 /* SectionThridHorizontalCollectionViewCell.swift */,
+				178336072B0E5790000DF127 /* ThridSectionHorizontalCollectionViewCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -771,7 +771,7 @@
 				3F52DDCC2B0B531E00BD216E /* CartViewController.swift in Sources */,
 				3F52DDCE2B0B53B200BD216E /* CartView.swift in Sources */,
 				17A8709B2B0864BB00D5162C /* DataModel.swift in Sources */,
-				178336082B0E5790000DF127 /* SectionThridHorizontalCollectionViewCell.swift in Sources */,
+				178336082B0E5790000DF127 /* ThridSectionHorizontalCollectionViewCell.swift in Sources */,
 				17A870932B08649300D5162C /* View.swift in Sources */,
 				09DE08382B05B70100D7DF3D /* SceneDelegate.swift in Sources */,
 				17A870972B0864A600D5162C /* Cell.swift in Sources */,

--- a/Kurly/Kurly/Presentation/Detail/Views/DetailView.swift
+++ b/Kurly/Kurly/Presentation/Detail/Views/DetailView.swift
@@ -42,8 +42,8 @@ final class DetailView: BaseView {
     private func setRegister() {
         self.detailCollectionView.register(FirstSectionCollectionViewCell.self, forCellWithReuseIdentifier: FirstSectionCollectionViewCell.identifier)
         self.detailCollectionView.register(SecondSectionCollectionViewCell.self, forCellWithReuseIdentifier: SecondSectionCollectionViewCell.identifier)
-        self.detailCollectionView.register(SectionThridHorizontalCollectionViewCell.self,
-                                                              forCellWithReuseIdentifier: SectionThridHorizontalCollectionViewCell.identifier)
+        self.detailCollectionView.register(ThridSectionHorizontalCollectionViewCell.self,
+                                                              forCellWithReuseIdentifier: ThridSectionHorizontalCollectionViewCell.identifier)
         self.detailCollectionView.register(RecommendHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: RecommendHeaderView.identifier)
     }
    
@@ -102,7 +102,7 @@ extension DetailView: UICollectionViewDelegate, UICollectionViewDataSource {
             return item
             
         case 2:
-            guard let item = detailCollectionView.dequeueReusableCell(withReuseIdentifier: SectionThridHorizontalCollectionViewCell.identifier, for: indexPath) as? SectionThridHorizontalCollectionViewCell else {return UICollectionViewCell()}
+            guard let item = detailCollectionView.dequeueReusableCell(withReuseIdentifier: ThridSectionHorizontalCollectionViewCell.identifier, for: indexPath) as? ThridSectionHorizontalCollectionViewCell else {return UICollectionViewCell()}
             return item
             
         default:

--- a/Kurly/Kurly/Presentation/Detail/Views/DetailView.swift
+++ b/Kurly/Kurly/Presentation/Detail/Views/DetailView.swift
@@ -71,7 +71,8 @@ extension DetailView {
     }
 }
 
-extension DetailView: UICollectionViewDelegate, UICollectionViewDataSource {
+extension DetailView: UICollectionViewDelegate {}
+extension DetailView: UICollectionViewDataSource {
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         return 7

--- a/Kurly/Kurly/Presentation/Detail/Views/DetailView.swift
+++ b/Kurly/Kurly/Presentation/Detail/Views/DetailView.swift
@@ -38,10 +38,13 @@ final class DetailView: BaseView {
     private func basicSetup() {
         self.detailCollectionView.register(FirstSectionCollectionViewCell.self, forCellWithReuseIdentifier: FirstSectionCollectionViewCell.identifier)
         self.detailCollectionView.register(SecondSectionCollectionViewCell.self, forCellWithReuseIdentifier: SecondSectionCollectionViewCell.identifier)
+        self.detailCollectionView.register(SectionThridHorizontalCollectionViewCell.self,
+                                                              forCellWithReuseIdentifier: SectionThridHorizontalCollectionViewCell.identifier)
+        self.detailCollectionView.register(RecommendHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: RecommendHeaderView.identifier)
         self.detailCollectionView.delegate = self
         self.detailCollectionView.dataSource = self
     }
-    
+   
     override func setUI() {
         detailCollectionView.do {
             $0.backgroundColor = .white
@@ -78,6 +81,8 @@ extension DetailView: UICollectionViewDelegate, UICollectionViewDataSource {
             return sections[section].count
         case 1:
             return 1
+        case 2:
+            return 1
         default:
             return 0
         }
@@ -92,6 +97,10 @@ extension DetailView: UICollectionViewDelegate, UICollectionViewDataSource {
             
         case 1:
             guard let item = detailCollectionView.dequeueReusableCell(withReuseIdentifier: SecondSectionCollectionViewCell.identifier, for: indexPath) as? SecondSectionCollectionViewCell else {return UICollectionViewCell()}
+            return item
+            
+        case 2:
+            guard let item = detailCollectionView.dequeueReusableCell(withReuseIdentifier: SectionThridHorizontalCollectionViewCell.identifier, for: indexPath) as? SectionThridHorizontalCollectionViewCell else {return UICollectionViewCell()}
             return item
             
         default:
@@ -111,8 +120,40 @@ extension DetailView: UICollectionViewDelegateFlowLayout {
         case 1:
             let itemHeight: CGFloat = SizeLiterals.Screen.screenHeight * 132 / 812
             return CGSize(width: collectionView.frame.width, height: itemHeight)
+            
+        case 2:
+            return CGSize(width: collectionView.frame.width, height: SizeLiterals.Screen.screenHeight * 276 / 812)
+
         default:
             return CGSize(width: collectionView.frame.width, height: collectionView.frame.height)
         }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+        switch section {
+        case 2:
+            return CGSize(width: collectionView.bounds.width, height: 61)
+            
+        default:
+            return .zero
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        switch indexPath.section {
+        case 2:
+            if kind == UICollectionView.elementKindSectionHeader {
+                guard let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: RecommendHeaderView.identifier, for: indexPath) as? RecommendHeaderView else { return UICollectionReusableView()}
+                headerView.bindData(sectionText: "다른 고객이 함께 본 상품")
+                return headerView
+            }
+        default:
+            return UICollectionReusableView()
+        }
+        return UICollectionReusableView()
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 0
     }
 }

--- a/Kurly/Kurly/Presentation/Detail/Views/DetailView.swift
+++ b/Kurly/Kurly/Presentation/Detail/Views/DetailView.swift
@@ -22,8 +22,6 @@ final class DetailView: BaseView {
         super.init(frame: frame)
         bindModel()
         basicSetup()
-        setUI()
-        setLayout()
     }
     
     required init?(coder: NSCoder) {

--- a/Kurly/Kurly/Presentation/Detail/Views/DetailView.swift
+++ b/Kurly/Kurly/Presentation/Detail/Views/DetailView.swift
@@ -21,7 +21,8 @@ final class DetailView: BaseView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         bindModel()
-        basicSetup()
+        setDelegates()
+        setRegister()
     }
     
     required init?(coder: NSCoder) {
@@ -33,14 +34,17 @@ final class DetailView: BaseView {
         print("🧵 \(DetailView()) has been successfully Removed")
     }
     
-    private func basicSetup() {
+    private func setDelegates() {
+        self.detailCollectionView.delegate = self
+        self.detailCollectionView.dataSource = self
+    }
+    
+    private func setRegister() {
         self.detailCollectionView.register(FirstSectionCollectionViewCell.self, forCellWithReuseIdentifier: FirstSectionCollectionViewCell.identifier)
         self.detailCollectionView.register(SecondSectionCollectionViewCell.self, forCellWithReuseIdentifier: SecondSectionCollectionViewCell.identifier)
         self.detailCollectionView.register(SectionThridHorizontalCollectionViewCell.self,
                                                               forCellWithReuseIdentifier: SectionThridHorizontalCollectionViewCell.identifier)
         self.detailCollectionView.register(RecommendHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: RecommendHeaderView.identifier)
-        self.detailCollectionView.delegate = self
-        self.detailCollectionView.dataSource = self
     }
    
     override func setUI() {

--- a/Kurly/Kurly/Presentation/Detail/Views/SectionThridHorizontalCollectionViewCell.swift
+++ b/Kurly/Kurly/Presentation/Detail/Views/SectionThridHorizontalCollectionViewCell.swift
@@ -1,0 +1,90 @@
+//
+//  SectionThridHorizontalCollectionViewCell.swift
+//  Kurly
+//
+//  Created by 김보연 on 11/23/23.
+//
+
+import UIKit
+
+class SectionThridHorizontalCollectionViewCell: UICollectionViewCell {
+    
+    static let identifier: String = "SectionThridHorizontalCollectionViewCell"
+    
+    private lazy var horizontalCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
+    
+    private let relatedFoodModalView = RelatedFoodModalView()
+    private var relatedFoodList: [RecommendModel] = [
+        .init(foodImage: ImageLiterals.Home.img.activityTop01, foodName: "[시골보쌈과 감자옹심이 감자...", foodPrice: "10,500원"),
+        .init(foodImage: ImageLiterals.Home.img.activityTop02, foodName: "[이연복의 목란] 짬뽕 2인분...", foodPrice: "13,800원"),
+        .init(foodImage: ImageLiterals.Home.img.activityTop03, foodName: "[방방곡곡] 비빔국수 키트(2인...", foodPrice: "9,900원"),
+        .init(foodImage: ImageLiterals.Home.img.activityTop01, foodName: "[시골보쌈과 감자옹심이 감자...", foodPrice: "10,500원"),
+        .init(foodImage: ImageLiterals.Home.img.activityTop02, foodName: "[이연복의 목란] 짬뽕 2인분...", foodPrice: "13,800원"),
+        .init(foodImage: ImageLiterals.Home.img.activityTop03, foodName: "[방방곡곡] 비빔국수 키트(2인...", foodPrice: "9,900원")
+    ]
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        basicSetup()
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func basicSetup() {
+        self.horizontalCollectionView.register(RecommendCollectionViewCell.self,
+                                               forCellWithReuseIdentifier: RecommendCollectionViewCell.identifier)
+        relatedFoodModalView.recommendCollectionView.register(RecommendCollectionViewCell.self,
+                                                              forCellWithReuseIdentifier: RecommendCollectionViewCell.identifier)
+        self.horizontalCollectionView.delegate = self
+        self.horizontalCollectionView.dataSource = self
+    }
+    
+    private func setUI() {
+        horizontalCollectionView.do {
+            $0.backgroundColor = .clear
+            let flowLayout = UICollectionViewFlowLayout()
+            flowLayout.scrollDirection = .horizontal
+            $0.collectionViewLayout = flowLayout
+        }
+    }
+    
+    private func setLayout() {
+        self.addSubview(horizontalCollectionView)
+        
+        horizontalCollectionView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}
+
+extension SectionThridHorizontalCollectionViewCell: UICollectionViewDelegate, UICollectionViewDataSource {
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 6
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let item = collectionView.dequeueReusableCell(withReuseIdentifier: RecommendCollectionViewCell.identifier, for: indexPath) as? RecommendCollectionViewCell else { return UICollectionViewCell()}
+        item.bindData(cellData: relatedFoodList[indexPath.row])
+        return item
+    }
+}
+
+extension SectionThridHorizontalCollectionViewCell: UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: 120, height: 276)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        return UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout flowLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return CGFloat(8)
+    }
+}

--- a/Kurly/Kurly/Presentation/Detail/Views/ThridSectionHorizontalCollectionViewCell.swift
+++ b/Kurly/Kurly/Presentation/Detail/Views/ThridSectionHorizontalCollectionViewCell.swift
@@ -61,7 +61,8 @@ class ThridSectionHorizontalCollectionViewCell: UICollectionViewCell {
     }
 }
 
-extension ThridSectionHorizontalCollectionViewCell: UICollectionViewDelegate, UICollectionViewDataSource {
+extension ThridSectionHorizontalCollectionViewCell: UICollectionViewDelegate {}
+extension ThridSectionHorizontalCollectionViewCell: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return 6

--- a/Kurly/Kurly/Presentation/Detail/Views/ThridSectionHorizontalCollectionViewCell.swift
+++ b/Kurly/Kurly/Presentation/Detail/Views/ThridSectionHorizontalCollectionViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  SectionThridHorizontalCollectionViewCell.swift
+//  ThridThridSectionHorizontalCollectionViewCellHorizontalCollectionViewCell.swift
 //  Kurly
 //
 //  Created by 김보연 on 11/23/23.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class SectionThridHorizontalCollectionViewCell: UICollectionViewCell {
+class ThridSectionHorizontalCollectionViewCell: UICollectionViewCell {
     
     static let identifier: String = "SectionThridHorizontalCollectionViewCell"
     
@@ -61,7 +61,7 @@ class SectionThridHorizontalCollectionViewCell: UICollectionViewCell {
     }
 }
 
-extension SectionThridHorizontalCollectionViewCell: UICollectionViewDelegate, UICollectionViewDataSource {
+extension ThridSectionHorizontalCollectionViewCell: UICollectionViewDelegate, UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return 6
@@ -74,7 +74,7 @@ extension SectionThridHorizontalCollectionViewCell: UICollectionViewDelegate, UI
     }
 }
 
-extension SectionThridHorizontalCollectionViewCell: UICollectionViewDelegateFlowLayout {
+extension ThridSectionHorizontalCollectionViewCell: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return CGSize(width: 120, height: 276)


### PR DESCRIPTION
## 🍧 작업한 내용

<!-- 작업하게 된 배경을 간단히 적어주세요! -->
- 수평스크롤 컬렉션 뷰 파일 생성
- 수평스크롤 컬렉션 뷰의 셀에 모달과 공통된 셀 호출
- 전체 컬렉션 뷰의 세 번째 섹션에 수평스크롤 컬렉션 뷰 호출
- 전체 컬렉션 뷰의 세 번째 섹션에 모달과 공통된 헤더 뷰 호출

## 🚨 참고 사항

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 헤더 뷰와 수평스크롤 컬렉션 뷰의 간격이 살짝 안맞습니다,, 차차 수정할게요

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 수평 스크롤 | <img src = "https://github.com/DO-SOPT-CDS-APP-7/Kurly-iOS/assets/73578631/d097fff9-e474-401b-93c2-79d7c07b05d5" width ="250">|


## 😈 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #31
