### PR TITLE
[Feature] #52 주문 완료 뷰를 상, 하단을 구현했습니다.

### DIFF
--- a/Kurly/Kurly.xcodeproj/project.pbxproj
+++ b/Kurly/Kurly.xcodeproj/project.pbxproj
@@ -82,6 +82,8 @@
 		3F6E80F32B0C5E1E00D89606 /* CartHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6E80F22B0C5E1E00D89606 /* CartHeaderView.swift */; };
 		3F6E80F62B0DE77F00D89606 /* CartItemHeaderCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6E80F52B0DE77F00D89606 /* CartItemHeaderCollectionReusableView.swift */; };
 		3F6E80F82B0DEAD200D89606 /* CartItemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6E80F72B0DEAD100D89606 /* CartItemCollectionViewCell.swift */; };
+		3FE4CCEA2B10C4AF009C9029 /* CompletedOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE4CCE92B10C4AF009C9029 /* CompletedOrderViewController.swift */; };
+		3FE4CCEC2B10C4D7009C9029 /* CompletedOrderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE4CCEB2B10C4D7009C9029 /* CompletedOrderView.swift */; };
 		F15DD1D32B0C8C3C00984E6D /* sampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15DD1D22B0C8C3C00984E6D /* sampleViewController.swift */; };
 		F15DD1D52B0C8C6600984E6D /* NotifyAddToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15DD1D42B0C8C6600984E6D /* NotifyAddToastView.swift */; };
 		F15DD1D72B0C8C7E00984E6D /* NotifyRemoveToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15DD1D62B0C8C7E00984E6D /* NotifyRemoveToastView.swift */; };
@@ -168,6 +170,8 @@
 		3F6E80F22B0C5E1E00D89606 /* CartHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartHeaderView.swift; sourceTree = "<group>"; };
 		3F6E80F52B0DE77F00D89606 /* CartItemHeaderCollectionReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartItemHeaderCollectionReusableView.swift; sourceTree = "<group>"; };
 		3F6E80F72B0DEAD100D89606 /* CartItemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartItemCollectionViewCell.swift; sourceTree = "<group>"; };
+		3FE4CCE92B10C4AF009C9029 /* CompletedOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletedOrderViewController.swift; sourceTree = "<group>"; };
+		3FE4CCEB2B10C4D7009C9029 /* CompletedOrderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletedOrderView.swift; sourceTree = "<group>"; };
 		F15DD1D22B0C8C3C00984E6D /* sampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = sampleViewController.swift; sourceTree = "<group>"; };
 		F15DD1D42B0C8C6600984E6D /* NotifyAddToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifyAddToastView.swift; sourceTree = "<group>"; };
 		F15DD1D62B0C8C7E00984E6D /* NotifyRemoveToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifyRemoveToastView.swift; sourceTree = "<group>"; };
@@ -438,6 +442,7 @@
 		17A8707A2B08631200D5162C /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				3FE4CCE62B10C43E009C9029 /* CompletedOrder  */,
 				F15DD1D82B0C966100984E6D /* RelatedFoodModal */,
 				F15DD1CF2B0C8BDF00984E6D /* FavoriteFood */,
 				3F52DDC82B0B52B000BD216E /* Cart */,
@@ -643,6 +648,31 @@
 			path = Cells;
 			sourceTree = "<group>";
 		};
+		3FE4CCE62B10C43E009C9029 /* CompletedOrder  */ = {
+			isa = PBXGroup;
+			children = (
+				3FE4CCE82B10C482009C9029 /* Views */,
+				3FE4CCE72B10C471009C9029 /* ViewController */,
+			);
+			path = "CompletedOrder ";
+			sourceTree = "<group>";
+		};
+		3FE4CCE72B10C471009C9029 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				3FE4CCE92B10C4AF009C9029 /* CompletedOrderViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		3FE4CCE82B10C482009C9029 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				3FE4CCEB2B10C4D7009C9029 /* CompletedOrderView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		F15DD1CF2B0C8BDF00984E6D /* FavoriteFood */ = {
 			isa = PBXGroup;
 			children = (
@@ -818,6 +848,7 @@
 				17A870C02B086DE900D5162C /* ColorLiterals.swift in Sources */,
 				09CE00FB2B0E12BC00CB42C4 /* Int+.swift in Sources */,
 				097F58082B0EFE6B00918304 /* RelatedCollectionViewCell.swift in Sources */,
+				3FE4CCEC2B10C4D7009C9029 /* CompletedOrderView.swift in Sources */,
 				09BA86BB2B0A6F0E00BF85D9 /* BottomCTAButton.swift in Sources */,
 				174713732B0FDAFC00E8EC51 /* DetailBottomBarView.swift in Sources */,
 				09EAE9972B0B3CB40079CAC4 /* AfterAddCartViewController.swift in Sources */,
@@ -841,6 +872,7 @@
 				F15DD1E32B0CBBB800984E6D /* RecommendHeaderView.swift in Sources */,
 				097266F62B0A134B00FB6E54 /* BaseViewController.swift in Sources */,
 				178335FE2B0B4DA1000DF127 /* DetailView.swift in Sources */,
+				3FE4CCEA2B10C4AF009C9029 /* CompletedOrderViewController.swift in Sources */,
 				F15DD1E12B0C9CAB00984E6D /* RecommendCollectionViewCell.swift in Sources */,
 				17A870852B0863A600D5162C /* Protocols.swift in Sources */,
 				178336022B0B6832000DF127 /* DetailProduct.swift in Sources */,

--- a/Kurly/Kurly/Presentation/CompletedOrder /ViewController/CompletedOrderViewController.swift
+++ b/Kurly/Kurly/Presentation/CompletedOrder /ViewController/CompletedOrderViewController.swift
@@ -1,0 +1,45 @@
+//
+//  CompletedOrderViewController.swift
+//  Kurly
+//
+//  Created by ParkJunHyuk on 2023/11/24.
+//
+
+import UIKit
+
+class CompletedOrderViewController: BaseViewController {
+
+    private let completedOrderView = CompletedOrderView()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    override func loadView() {
+        self.view = completedOrderView
+    }
+    
+    override func setUI() {
+        self.view.backgroundColor = .white
+    }
+}
+
+extension CompletedOrderViewController {
+    
+    private func setTarget() {
+        completedOrderView.orderDetailCTAButton.addTarget(self, action: #selector(tapOrderDetailCTAButton), for: .touchUpInside)
+        
+        completedOrderView.shoppingCTAButton.addTarget(self, action: #selector(tapShoppingCTAButton), for: .touchUpInside)
+    }
+}
+
+extension CompletedOrderViewController {
+    
+    @objc func tapOrderDetailCTAButton() {
+        print("주문 상세보기!")
+    }
+    
+    @objc func tapShoppingCTAButton() {
+        print("쇼핑 계속하기!")
+    }
+}

--- a/Kurly/Kurly/Presentation/CompletedOrder /Views/CompletedOrderView.swift
+++ b/Kurly/Kurly/Presentation/CompletedOrder /Views/CompletedOrderView.swift
@@ -1,0 +1,68 @@
+//
+//  CompletedOrderView.swift
+//  Kurly
+//
+//  Created by ParkJunHyuk on 2023/11/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class CompletedOrderView: BaseView {
+    
+    private let completedImageView = UIImageView()
+    private let completedTitelLabel = UILabel()
+    let orderDetailCTAButton = BottomCTAButton(type: .orderDetail)
+    let shoppingCTAButton = BottomCTAButton(type: .shopping)
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setUI() {
+        self.backgroundColor = .white
+        
+        completedImageView.do {
+            $0.image = ImageLiterals.Home.icn.checkButton
+        }
+        
+        completedTitelLabel.do {
+            $0.text = "마켓컬리님의 주문이 완료되었습니다.\n내일 아침에 만나요!"
+            $0.font = .fontGuide(.title_semibold_20)
+            $0.textColor = .gray7
+            $0.numberOfLines = 2
+            $0.lineBreakMode = .byCharWrapping
+            $0.textAlignment = .center
+        }
+    }
+    
+    override func setLayout() {
+        self.addSubviews(completedImageView, completedTitelLabel, orderDetailCTAButton, shoppingCTAButton)
+        
+        completedImageView.snp.makeConstraints{
+            $0.top.equalTo(self.safeAreaLayoutGuide).offset(48)
+            $0.horizontalEdges.equalToSuperview().inset(153)
+        }
+        
+        completedTitelLabel.snp.makeConstraints{
+            $0.top.equalTo(completedImageView.snp.bottom).offset(12)
+            $0.horizontalEdges.equalToSuperview().inset(41)
+        }
+        
+        orderDetailCTAButton.snp.makeConstraints{
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.bottom.equalTo(shoppingCTAButton.snp.top).inset(-14)
+        }
+        
+        shoppingCTAButton.snp.makeConstraints{
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(10)
+        }
+    }
+}

--- a/Kurly/Kurly/Presentation/CompletedOrder /Views/CompletedOrderView.swift
+++ b/Kurly/Kurly/Presentation/CompletedOrder /Views/CompletedOrderView.swift
@@ -47,7 +47,7 @@ class CompletedOrderView: BaseView {
         
         completedImageView.snp.makeConstraints{
             $0.top.equalTo(self.safeAreaLayoutGuide).offset(48)
-            $0.horizontalEdges.equalToSuperview().inset(153)
+            $0.centerX.equalToSuperview()
         }
         
         completedTitelLabel.snp.makeConstraints{


### PR DESCRIPTION
## 🍧 작업한 내용

<!-- 작업하게 된 배경을 간단히 적어주세요! -->
- `CompletedOrderViewController` 구현
- `CompletedOrderView` 구현
- 상단의 `ImageView` 와 `Label` 및 하단의 버튼 구현

## 🚨 참고 사항

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 다음 작업에 정보란을 보여주는 가운데 부분을 구현할 예정입니다!

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
|주문완료 뷰 | <img src = "https://github.com/DO-SOPT-CDS-APP-7/Kurly-iOS/assets/45564605/b7227990-0f0f-4989-aa18-bc152253e02c" width ="250">|

## 😈 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #52 
