### PR TITLE
[Fix] #69 - ToastView 레이아웃 수정

### DIFF
--- a/Kurly/Kurly/Presentation/FavoriteFood/View/NotifyAddToastView.swift
+++ b/Kurly/Kurly/Presentation/FavoriteFood/View/NotifyAddToastView.swift
@@ -58,7 +58,6 @@ final class NotifyAddToastView: BaseView {
         backgroundView.addSubviews(notifyMessageLabel, shortcutButton, shortcutImageView)
         
         self.snp.makeConstraints {
-            $0.width.equalTo(SizeLiterals.Screen.screenWidth)
             $0.height.equalTo(51)
         }
         

--- a/Kurly/Kurly/Presentation/FavoriteFood/View/NotifyRemoveToastView.swift
+++ b/Kurly/Kurly/Presentation/FavoriteFood/View/NotifyRemoveToastView.swift
@@ -44,7 +44,6 @@ final class NotifyRemoveToastView: BaseView {
         backgroundView.addSubview(notifyMessageLabel)
         
         self.snp.makeConstraints {
-            $0.width.equalTo(SizeLiterals.Screen.screenWidth)
             $0.height.equalTo(51)
         }
         


### PR DESCRIPTION
## 🍧 작업한 내용

<!-- 작업하게 된 배경을 간단히 적어주세요! -->
- DetailView와 ToastView의 레이아웃에서 오류가 발생했습니다.

## 🚨 참고 사항

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 2개의 ToastView에서 중복으로 width값을 정한 것을 제거했습니다.

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| PNG | <img src = "https://github.com/DO-SOPT-CDS-APP-7/Kurly-iOS/assets/62370742/95fe9102-81d5-46d7-9463-1c4648d2bd73" width ="250">|

## 😈 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: [Fix] DetailView와 ToastView의 레이아웃 오류를 수정하겠습니다. #69
