### PR TITLE
[Feature] #82 - 장바구니 뷰 Sticky Header 구현했습니다.

### DIFF
--- a/Kurly/Kurly.xcodeproj/project.pbxproj
+++ b/Kurly/Kurly.xcodeproj/project.pbxproj
@@ -97,6 +97,8 @@
 		3FE6C36E2B11CFA400209599 /* EmptyItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE6C36D2B11CFA400209599 /* EmptyItemView.swift */; };
 		3FE6C3712B14333B00209599 /* CartModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE6C3702B14333B00209599 /* CartModel.swift */; };
 		3FE6C3732B14CE0A00209599 /* OrderModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE6C3722B14CE0A00209599 /* OrderModel.swift */; };
+		3FE6C3752B15007000209599 /* CartAddressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE6C3742B15007000209599 /* CartAddressView.swift */; };
+		3FE6C3772B15C53A00209599 /* AllSelectedItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE6C3762B15C53A00209599 /* AllSelectedItemView.swift */; };
 		F15DD1D52B0C8C6600984E6D /* NotifyAddToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15DD1D42B0C8C6600984E6D /* NotifyAddToastView.swift */; };
 		F15DD1D72B0C8C7E00984E6D /* NotifyRemoveToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15DD1D62B0C8C7E00984E6D /* NotifyRemoveToastView.swift */; };
 		F15DD1DC2B0C96E700984E6D /* RelatedFoodModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15DD1DB2B0C96E700984E6D /* RelatedFoodModalViewController.swift */; };
@@ -197,6 +199,8 @@
 		3FE6C36D2B11CFA400209599 /* EmptyItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyItemView.swift; sourceTree = "<group>"; };
 		3FE6C3702B14333B00209599 /* CartModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartModel.swift; sourceTree = "<group>"; };
 		3FE6C3722B14CE0A00209599 /* OrderModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderModel.swift; sourceTree = "<group>"; };
+		3FE6C3742B15007000209599 /* CartAddressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartAddressView.swift; sourceTree = "<group>"; };
+		3FE6C3762B15C53A00209599 /* AllSelectedItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllSelectedItemView.swift; sourceTree = "<group>"; };
 		F15DD1D42B0C8C6600984E6D /* NotifyAddToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifyAddToastView.swift; sourceTree = "<group>"; };
 		F15DD1D62B0C8C7E00984E6D /* NotifyRemoveToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifyRemoveToastView.swift; sourceTree = "<group>"; };
 		F15DD1DB2B0C96E700984E6D /* RelatedFoodModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelatedFoodModalViewController.swift; sourceTree = "<group>"; };
@@ -670,6 +674,8 @@
 				3FE4CCE42B108B67009C9029 /* CartItemFooterCollectionReusableView.swift */,
 				3FE4CCE22B103244009C9029 /* SavePointView.swift */,
 				3FE6C36D2B11CFA400209599 /* EmptyItemView.swift */,
+				3FE6C3742B15007000209599 /* CartAddressView.swift */,
+				3FE6C3762B15C53A00209599 /* AllSelectedItemView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -919,6 +925,7 @@
 				09DE08362B05B70100D7DF3D /* AppDelegate.swift in Sources */,
 				F15DD1D52B0C8C6600984E6D /* NotifyAddToastView.swift in Sources */,
 				09BA86942B0A3BF200BF85D9 /* SizeLiterals.swift in Sources */,
+				3FE6C3772B15C53A00209599 /* AllSelectedItemView.swift in Sources */,
 				178336002B0B61E3000DF127 /* FirstSectionCollectionViewCell.swift in Sources */,
 				174713712B0FA05400E8EC51 /* SixthSectionCollectionViewCell.swift in Sources */,
 				09BA86B52B0A4E7C00BF85D9 /* TabBarRect.swift in Sources */,
@@ -960,6 +967,7 @@
 				17A870C82B08A43A00D5162C /* UIButton+.swift in Sources */,
 				09EAE9862B0B05170079CAC4 /* AddCartViewController.swift in Sources */,
 				F15DD1DC2B0C96E700984E6D /* RelatedFoodModalViewController.swift in Sources */,
+				3FE6C3752B15007000209599 /* CartAddressView.swift in Sources */,
 				F15DD1D72B0C8C7E00984E6D /* NotifyRemoveToastView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Kurly/Kurly/Presentation/Cart/Cells/CartItemCollectionViewCell.swift
+++ b/Kurly/Kurly/Presentation/Cart/Cells/CartItemCollectionViewCell.swift
@@ -50,6 +50,8 @@ final class CartItemCollectionViewCell: UICollectionViewCell, CollectionViewCell
         itemLabel.do {
             $0.font = .fontGuide(.body_medium_15)
             $0.textColor = .gray6
+            $0.numberOfLines = 2
+            $0.lineBreakMode = .byWordWrapping
         }
         
         deleteItemButton.do {
@@ -97,6 +99,14 @@ final class CartItemCollectionViewCell: UICollectionViewCell, CollectionViewCell
     
     private func setLayout() {
         self.addSubviews(topStackView, itemImageView, priceStackView, stepper)
+        
+        selectItemButton.snp.makeConstraints {
+            $0.width.equalTo(36)
+        }
+        
+        deleteItemButton.snp.makeConstraints {
+            $0.width.equalTo(36)
+        }
         
         topStackView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(14)

--- a/Kurly/Kurly/Presentation/Cart/Cells/CartItemCollectionViewCell.swift
+++ b/Kurly/Kurly/Presentation/Cart/Cells/CartItemCollectionViewCell.swift
@@ -81,7 +81,7 @@ final class CartItemCollectionViewCell: UICollectionViewCell, CollectionViewCell
         
         topStackView.do {
             $0.axis = .horizontal
-            $0.distribution = .fillProportionally
+            $0.distribution = .fill
             $0.spacing = 6
             $0.addArrangedSubviews(selectItemButton, itemLabel, deleteItemButton)
             itemLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)

--- a/Kurly/Kurly/Presentation/Cart/ViewControllers/CartViewController.swift
+++ b/Kurly/Kurly/Presentation/Cart/ViewControllers/CartViewController.swift
@@ -20,10 +20,11 @@ final class CartViewController: BaseViewController {
     private var dummy = CartModel.dummy()
     private var selectedItem: [CartModel] = [] {
         didSet {
-            cartView.cartHeaderView.bindData(seletedItemCount: selectedItem.count, AllItemCount: dummy.count)
+            cartView.cartHeaderView.allSelectedItemView.bindData(seletedItemCount: selectedItem.count, AllItemCount: dummy.count)
             
             let result = calculateSelectedItemPrice(seletedItem: self.selectedItem)
             cartView.bindPrice(totalPrice: result.totalPrice)
+            
             cartView.cartItemCollectionView.reloadData()
         }
     }
@@ -114,7 +115,9 @@ extension CartViewController: UpdatingStepperProtocol {
 extension CartViewController {
     
     private func bindModel() {
-        cartView.cartHeaderView.bindData(seletedItemCount: selectedItem.count, AllItemCount: dummy.count)
+        cartView.cartHeaderView.allSelectedItemView.bindData(seletedItemCount: selectedItem.count, AllItemCount: dummy.count)
+        
+        cartView.bindPrice(totalPrice: 0)
     }
     
     private func setTarget() {
@@ -122,11 +125,11 @@ extension CartViewController {
         
         cartView.bottomCTAButton.addTarget(self, action: #selector(tapOrderButton), for: .touchUpInside)
         
-        cartView.cartHeaderView.changeAddressButton.addTarget(self, action: #selector(tapChangeAddressButton), for: .touchUpInside)
+        cartView.cartHeaderView.cartAddressView.changeAddressButton.addTarget(self, action: #selector(tapChangeAddressButton), for: .touchUpInside)
         
-        cartView.cartHeaderView.selectAllItemButton.addTarget(self, action: #selector(tapSelectAllItemButton), for: .touchUpInside)
+        cartView.cartHeaderView.allSelectedItemView.selectAllItemButton.addTarget(self, action: #selector(tapSelectAllItemButton), for: .touchUpInside)
         
-        cartView.cartHeaderView.selectDeleteItemButton.addTarget(self, action: #selector(tapSelectDeleteItemButton), for: .touchUpInside)
+        cartView.cartHeaderView.allSelectedItemView.selectDeleteItemButton.addTarget(self, action: #selector(tapSelectDeleteItemButton), for: .touchUpInside)
     }
 }
 
@@ -278,5 +281,13 @@ extension CartViewController: UICollectionViewDelegateFlowLayout {
         } else {
             return CGSize(width: collectionView.bounds.width, height: 0)
         }
+    }
+}
+
+extension CartViewController: UIScrollViewDelegate {
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let yOffset = scrollView.contentOffset.y
+        self.cartView.updateView(forScrollOffset: yOffset)
     }
 }

--- a/Kurly/Kurly/Presentation/Cart/ViewControllers/CartViewController.swift
+++ b/Kurly/Kurly/Presentation/Cart/ViewControllers/CartViewController.swift
@@ -287,5 +287,6 @@ extension CartViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let yOffset = scrollView.contentOffset.y
         self.cartView.updateView(forScrollOffset: yOffset)
+        self.view.layoutIfNeeded()
     }
 }

--- a/Kurly/Kurly/Presentation/Cart/Views/AllSelectedItemView.swift
+++ b/Kurly/Kurly/Presentation/Cart/Views/AllSelectedItemView.swift
@@ -1,0 +1,81 @@
+//
+//  AllSelectedItemView.swift
+//  Kurly
+//
+//  Created by ParkJunHyuk on 2023/11/28.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class AllSelectedItemView: BaseView {
+
+    let selectAllItemButton = UIButton()
+    private let selectItemCountLabel = UILabel()
+    let selectDeleteItemButton = UIButton()
+    let mainStackView = UIStackView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func setUI() {
+        self.backgroundColor = .white
+        
+        selectAllItemButton.do {
+            $0.setImage(ImageLiterals.Home.icn.checkButtonDefault, for: .normal)
+            $0.setImage(ImageLiterals.Home.icn.checkButtonPressed, for: .selected)
+        }
+        
+        selectItemCountLabel.do {
+            $0.font = .fontGuide(.title_semibold_16)
+            $0.textColor = .gray5
+        }
+        
+        selectDeleteItemButton.do {
+            $0.setTitle("선택삭제", for: .normal)
+            $0.titleLabel?.font = .fontGuide(.body_medium_14)
+            $0.setTitleColor(.gray5, for: .normal)
+        }
+        
+        mainStackView.do {
+            $0.axis = .horizontal
+            $0.distribution = .fillProportionally
+            $0.spacing = 6
+            $0.addArrangedSubviews(selectAllItemButton, selectItemCountLabel, selectDeleteItemButton)
+            selectItemCountLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+            selectAllItemButton.setContentHuggingPriority(.required, for: .horizontal)
+            selectDeleteItemButton.setContentHuggingPriority(.required, for: .horizontal)
+        }
+    }
+    
+    override func setLayout() {
+        self.addSubviews(mainStackView)
+        
+        mainStackView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(6)
+            $0.leading.equalToSuperview().offset(14)
+            $0.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview().inset(6)
+        }
+    }
+}
+
+extension AllSelectedItemView {
+    
+    func bindData(seletedItemCount: Int, AllItemCount: Int) {
+        selectItemCountLabel.text = "전체선택 (\(seletedItemCount)/\(AllItemCount))"
+        
+        if seletedItemCount == AllItemCount {
+            selectAllItemButton.isSelected = true
+        } else {
+            selectAllItemButton.isSelected = false
+        }
+    }
+}

--- a/Kurly/Kurly/Presentation/Cart/Views/CartAddressView.swift
+++ b/Kurly/Kurly/Presentation/Cart/Views/CartAddressView.swift
@@ -1,0 +1,94 @@
+//
+//  CartAddressView.swift
+//  Kurly
+//
+//  Created by ParkJunHyuk on 2023/11/28.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class CartAddressView: BaseView {
+
+    private let locationImage = UIImageView()
+    private let addressLabel = UILabel()
+    private let deliveryTypeLabel = UILabel()
+    let changeAddressButton = UIButton()
+    private let addressStackView = UIStackView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func setUI() {
+        self.backgroundColor = .white
+        
+        addressLabel.do {
+            $0.text = "서울시 광진구 능동로 120\n건국대학교"
+            $0.numberOfLines = 2
+            $0.lineBreakMode = .byCharWrapping
+            $0.font = .fontGuide(.body_regular_15)
+            $0.textColor = .gray6
+        }
+        
+        deliveryTypeLabel.do {
+            $0.text = "샛별배송"
+            $0.font = .fontGuide(.body_regular_12)
+            $0.textColor = .kuPurple
+        }
+        
+        locationImage.do {
+            $0.image = ImageLiterals.Home.icn.locationButtonGray
+        }
+        
+        changeAddressButton.do {
+            $0.setTitle("변경", for: .normal)
+            $0.titleLabel?.font = .fontGuide(.title_regular_14)
+            $0.setTitleColor(.gray6, for: .normal)
+            $0.makeRoundBorder(cornerRadius: 4, borderWidth: 1, borderColor: .gray3)
+        }
+        
+        addressStackView.do {
+            $0.axis = .vertical
+            $0.distribution = .fill
+            $0.alignment = .fill
+            $0.spacing = 4.0
+            $0.addArrangedSubviews(addressLabel, deliveryTypeLabel)
+        }
+    }
+    
+    override func setLayout() {
+        self.addSubviews(locationImage, addressStackView, changeAddressButton)
+        
+        addressLabel.snp.makeConstraints {
+            $0.height.equalTo(36)
+        }
+        
+        locationImage.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.leading.equalToSuperview().offset(16)
+            $0.trailing.equalTo(addressStackView.snp.leading).inset(-10)
+            $0.bottom.equalToSuperview().inset(42)
+        }
+        
+        addressStackView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(5)
+            $0.trailing.equalTo(changeAddressButton.snp.leading).inset(-101)
+            $0.bottom.equalToSuperview().inset(13)
+        }
+        
+        changeAddressButton.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(3)
+            $0.trailing.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview().inset(38)
+            $0.width.equalTo(49)
+            $0.height.equalTo(31)
+        }
+    }
+}

--- a/Kurly/Kurly/Presentation/Cart/Views/CartHeaderView.swift
+++ b/Kurly/Kurly/Presentation/Cart/Views/CartHeaderView.swift
@@ -22,8 +22,6 @@ final class CartHeaderView: BaseView {
     init(type: CartViewType) {
         self.cartType = type
         super.init(frame: .zero)
-        setUI()
-        setLayout()
     }
     
     required init?(coder: NSCoder) {
@@ -58,7 +56,7 @@ final class CartHeaderView: BaseView {
             }
             
             allSelectedItemView.snp.makeConstraints {
-                self.headerTopConstraint = $0.top.equalToSuperview().offset(72).constraint
+                self.headerTopConstraint = $0.top.equalToSuperview().offset(73).constraint
                 $0.horizontalEdges.equalToSuperview()
                 $0.bottom.equalToSuperview()
             }

--- a/Kurly/Kurly/Presentation/Cart/Views/CartHeaderView.swift
+++ b/Kurly/Kurly/Presentation/Cart/Views/CartHeaderView.swift
@@ -13,16 +13,11 @@ import Then
 final class CartHeaderView: BaseView {
     
     var cartType: CartViewType
-    private let addressLabel = UILabel()
-    private let deliveryTypeLabel = UILabel()
-    private let locationImage = UIImageView()
-    let changeAddressButton = UIButton()
-    let selectAllItemButton = UIButton()
-    private let selectItemCountLabel = UILabel()
-    let selectDeleteItemButton = UIButton()
-    private let addressStackView = UIStackView()
-    private let bottomStackView = UIStackView()
-    private let divider = UIView()
+
+    let divider = UIView()
+    let cartAddressView = CartAddressView()
+    let allSelectedItemView = AllSelectedItemView()
+    var headerTopConstraint: Constraint?
     
     init(type: CartViewType) {
         self.cartType = type
@@ -38,65 +33,7 @@ final class CartHeaderView: BaseView {
     override func setUI() {
         self.backgroundColor = .white
         
-        addressLabel.do {
-            $0.text = "서울시 광진구 능동로 120\n건국대학교"
-            $0.numberOfLines = 2
-            $0.font = .fontGuide(.body_regular_15)
-            $0.textColor = .gray6
-        }
-        
-        deliveryTypeLabel.do {
-            $0.text = "샛별배송"
-            $0.font = .fontGuide(.body_regular_12)
-            $0.textColor = .kuPurple
-        }
-        
-        locationImage.do {
-            $0.image = ImageLiterals.Home.icn.locationButtonGray
-        }
-        
-        changeAddressButton.do {
-            $0.setTitle("변경", for: .normal)
-            $0.titleLabel?.font = .fontGuide(.title_regular_14)
-            $0.setTitleColor(.gray6, for: .normal)
-            $0.makeRoundBorder(cornerRadius: 4, borderWidth: 1, borderColor: .gray3)
-        }
-        
-        addressStackView.do {
-            $0.axis = .vertical
-            $0.distribution = .fillProportionally
-            $0.alignment = .leading
-            $0.spacing = 4.0
-            $0.addArrangedSubviews(addressLabel, deliveryTypeLabel)
-        }
-        
         if cartType == .order {
-            selectAllItemButton.do {
-                $0.setImage(ImageLiterals.Home.icn.checkButtonDefault, for: .normal)
-                $0.setImage(ImageLiterals.Home.icn.checkButtonPressed, for: .selected)
-            }
-            
-            selectItemCountLabel.do {
-                $0.font = .fontGuide(.title_semibold_16)
-                $0.textColor = .gray5
-            }
-            
-            selectDeleteItemButton.do {
-                $0.setTitle("선택삭제", for: .normal)
-                $0.titleLabel?.font = .fontGuide(.body_medium_14)
-                $0.setTitleColor(.gray5, for: .normal)
-            }
-            
-            bottomStackView.do {
-                $0.axis = .horizontal
-                $0.distribution = .fillProportionally
-                $0.spacing = 6
-                $0.addArrangedSubviews(selectAllItemButton, selectItemCountLabel, selectDeleteItemButton)
-                selectItemCountLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
-                selectAllItemButton.setContentHuggingPriority(.required, for: .horizontal)
-                selectDeleteItemButton.setContentHuggingPriority(.required, for: .horizontal)
-            }
-            
             divider.do {
                 $0.backgroundColor = .gray2
             }
@@ -104,53 +41,27 @@ final class CartHeaderView: BaseView {
     }
     
     override func setLayout() {
-        self.addSubviews(locationImage, addressStackView, changeAddressButton)
+        self.addSubview(cartAddressView)
         
-        locationImage.snp.makeConstraints {
+        cartAddressView.snp.makeConstraints {
             $0.top.equalToSuperview()
-            $0.leading.equalToSuperview().offset(16)
-            $0.trailing.equalTo(addressStackView.snp.leading).inset(-10)
+            $0.horizontalEdges.equalToSuperview()
         }
-        
-        addressStackView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(5)
-            $0.trailing.equalTo(changeAddressButton.snp.leading).inset(-101)
-        }
-        
-        changeAddressButton.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(3)
-            $0.trailing.equalToSuperview().inset(16)
-            $0.width.equalTo(49)
-            $0.height.equalTo(31)
-        }
-        
+
         if cartType == .order {
-            self.addSubviews(divider, bottomStackView)
+            self.addSubviews(divider, allSelectedItemView)
             
             divider.snp.makeConstraints {
-                $0.top.equalTo(addressStackView.snp.bottom).offset(12)
+                $0.top.equalTo(cartAddressView.snp.bottom)
                 $0.horizontalEdges.equalToSuperview()
                 $0.height.equalTo(0.5)
             }
             
-            bottomStackView.snp.makeConstraints {
-                $0.top.equalTo(divider.snp.bottom).offset(6)
-                $0.leading.equalToSuperview().offset(14)
-                $0.trailing.equalToSuperview().inset(20)
-                $0.bottom.equalToSuperview().inset(6)
+            allSelectedItemView.snp.makeConstraints {
+                self.headerTopConstraint = $0.top.equalToSuperview().offset(72).constraint
+                $0.horizontalEdges.equalToSuperview()
+                $0.bottom.equalToSuperview()
             }
-        }
-    }
-}
-
-extension CartHeaderView {
-    func bindData(seletedItemCount: Int, AllItemCount: Int) {
-        selectItemCountLabel.text = "전체선택 (\(seletedItemCount)/\(AllItemCount))"
-        
-        if seletedItemCount == AllItemCount {
-            selectAllItemButton.isSelected = true
-        } else {
-            selectAllItemButton.isSelected = false
         }
     }
 }

--- a/Kurly/Kurly/Presentation/Cart/Views/CartView.swift
+++ b/Kurly/Kurly/Presentation/Cart/Views/CartView.swift
@@ -20,6 +20,9 @@ final class CartView: BaseView {
     private let divider = UIView()
     private let emptyItemView = EmptyItemView()
     
+    private var cartAddressViewHeight: CGFloat?
+    private var navigationBarViewHeight: CGFloat?
+    
     init(type: CartViewType) {
         self.cartType = type
         self.cartHeaderView = CartHeaderView(type: type)
@@ -27,15 +30,22 @@ final class CartView: BaseView {
         super.init(frame: .zero)
         setUI()
         setLayout()
+        layoutSubviews()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        cartAddressViewHeight = cartHeaderView.cartAddressView.frame.size.height
+        navigationBarViewHeight = navigationBar.frame.size.height
+    }
+    
     override func setUI() {
         self.backgroundColor = .white
-
+        
         divider.do {
             $0.backgroundColor = . gray2
         }
@@ -44,15 +54,26 @@ final class CartView: BaseView {
             cartItemCollectionView.do {
                 $0.backgroundColor = .white
                 $0.showsVerticalScrollIndicator = false
+                $0.contentInset = UIEdgeInsets(top: 167 + 8, left: 0, bottom: 0, right: 0)
             }
         }
     }
     
     override func setLayout() {
-        self.addSubviews(navigationBar, cartHeaderView, divider, bottomCTAButton)
         
+        if cartType == .order {
+            self.addSubview(cartItemCollectionView)
+        
+            cartItemCollectionView.snp.makeConstraints {
+                $0.top.equalTo(self.safeAreaLayoutGuide)
+                $0.horizontalEdges.equalToSuperview()
+                $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(80)
+            }
+        }
+        
+        self.addSubviews(navigationBar, cartHeaderView, divider, bottomCTAButton)
         navigationBar.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(48)
+            $0.top.equalTo(self.safeAreaLayoutGuide)
             $0.horizontalEdges.equalToSuperview()
         }
         
@@ -80,14 +101,6 @@ final class CartView: BaseView {
                 $0.horizontalEdges.equalToSuperview()
                 $0.bottom.equalTo(bottomCTAButton.snp.top).inset(-214)
             }
-        } else if cartType == .order {
-            self.addSubview(cartItemCollectionView)
-            
-            cartItemCollectionView.snp.makeConstraints {
-                $0.top.equalTo(divider.snp.bottom)
-                $0.horizontalEdges.equalToSuperview()
-                $0.bottom.equalTo(bottomCTAButton.snp.top).inset(-9)
-            }
         }
     }
 }
@@ -96,5 +109,31 @@ extension CartView {
     
     func bindPrice(totalPrice: Int) {
         self.bottomCTAButton.setTitle("\(totalPrice.priceText) 주문하기", for: .normal)
+    }
+}
+
+extension CartView {
+    
+    func updateView(forScrollOffset yOffset: CGFloat) {
+    
+        let scrollyOffset = -yOffset - 175
+        
+        let cartAddressViewAlpha = max((30 + scrollyOffset) / (30 - 0), 0)
+        let dividerAlpha = max((10 + scrollyOffset) / (10 - 0), 0)
+        
+        cartHeaderView.cartAddressView.alpha = cartAddressViewAlpha
+        cartHeaderView.divider.alpha = dividerAlpha
+
+        let allSecletedItemViewTopConstraint = max(72 + scrollyOffset, 0)
+
+        if cartHeaderView.cartAddressView.alpha == 0 {
+            cartHeaderView.cartAddressView.isHidden = true
+            
+            cartHeaderView.headerTopConstraint?.update(offset: allSecletedItemViewTopConstraint)
+        } else {
+            cartHeaderView.cartAddressView.isHidden = false
+
+            cartHeaderView.headerTopConstraint?.update(offset: allSecletedItemViewTopConstraint)
+        }
     }
 }

--- a/Kurly/Kurly/Presentation/Cart/Views/CartView.swift
+++ b/Kurly/Kurly/Presentation/Cart/Views/CartView.swift
@@ -23,13 +23,13 @@ final class CartView: BaseView {
     private var cartAddressViewHeight: CGFloat?
     private var navigationBarViewHeight: CGFloat?
     
+    private var dividerHeightConstraint: Constraint?
+    
     init(type: CartViewType) {
         self.cartType = type
         self.cartHeaderView = CartHeaderView(type: type)
         self.bottomCTAButton = BottomCTAButton(type: type == .emptyCart ? .emptyCart : .order)
         super.init(frame: .zero)
-        setUI()
-        setLayout()
         layoutSubviews()
     }
     
@@ -85,7 +85,7 @@ final class CartView: BaseView {
         divider.snp.makeConstraints {
             $0.top.equalTo(cartHeaderView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(8)
+            self.dividerHeightConstraint = $0.height.equalTo(8).constraint
         }
 
         bottomCTAButton.snp.makeConstraints {
@@ -117,14 +117,19 @@ extension CartView {
     func updateView(forScrollOffset yOffset: CGFloat) {
     
         let scrollyOffset = -yOffset - 175
-        
+
         let cartAddressViewAlpha = max((30 + scrollyOffset) / (30 - 0), 0)
         let dividerAlpha = max((10 + scrollyOffset) / (10 - 0), 0)
         
         cartHeaderView.cartAddressView.alpha = cartAddressViewAlpha
         cartHeaderView.divider.alpha = dividerAlpha
 
-        let allSecletedItemViewTopConstraint = max(72 + scrollyOffset, 0)
+        let allSecletedItemViewTopConstraint = max(73 + scrollyOffset, 0)
+        let dividerHeigthConstraint = max(8 + scrollyOffset, 0)
+        
+        if dividerHeigthConstraint >= 0 && dividerHeigthConstraint <= 8 {
+            dividerHeightConstraint?.update(offset: dividerHeigthConstraint)
+        }
 
         if cartHeaderView.cartAddressView.alpha == 0 {
             cartHeaderView.cartAddressView.isHidden = true
@@ -135,5 +140,7 @@ extension CartView {
 
             cartHeaderView.headerTopConstraint?.update(offset: allSecletedItemViewTopConstraint)
         }
+        
+        self.layoutIfNeeded()
     }
 }


### PR DESCRIPTION
## 🍧 작업한 내용

<!-- 작업하게 된 배경을 간단히 적어주세요! -->
- 기존의 `CartHeaderView` 를 `AllSelectedItemView` 와 `CartAddressView` 로 분리 ( 각 View 를 숨기기 위해 )
- 스크롤 시 이동한 y 값을 받기 위해 `UIScrollViewDelegate` 채택
- y 값에 따라 `cartAddressView` 의 `alpha` 와 `isHidden` 설정
- 사라진 View 에 따른 Autolayout 재설정
- `CartItemCollectionViewCell` 의 `itemLabel` 이 2줄 시 바뀌는 UI 를 수정 
-  초기 로딩 시 하단 버튼의 금액 설정 ( 0 원 )

## 🚨 참고 사항

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 스크롤 시 Sticky Header 가 제대로 이루어지는지 확인해주세요!

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->


|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 장바구니 | <img src = "https://github.com/DO-SOPT-CDS-APP-7/Kurly-iOS/assets/45564605/2e017302-6c65-49b0-98f3-8154ae1a612c)" width ="250">|

## 😈 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #82 
