### PR TITLE
[Feature] #91 - 장바구니 조회 API 및 데이터 유무를 통한 화면 변경 구현했습니다

### DIFF
--- a/Kurly/Kurly.xcodeproj/project.pbxproj
+++ b/Kurly/Kurly.xcodeproj/project.pbxproj
@@ -110,6 +110,8 @@
 		3FE6C3732B14CE0A00209599 /* OrderModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE6C3722B14CE0A00209599 /* OrderModel.swift */; };
 		3FE6C3752B15007000209599 /* CartAddressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE6C3742B15007000209599 /* CartAddressView.swift */; };
 		3FE6C3772B15C53A00209599 /* AllSelectedItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE6C3762B15C53A00209599 /* AllSelectedItemView.swift */; };
+		3FE6C37D2B175A9A00209599 /* CartResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE6C37C2B175A9A00209599 /* CartResponse.swift */; };
+		3FE6C37F2B175AB800209599 /* CartCheckService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE6C37E2B175AB800209599 /* CartCheckService.swift */; };
 		F15DD1D52B0C8C6600984E6D /* NotifyAddToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15DD1D42B0C8C6600984E6D /* NotifyAddToastView.swift */; };
 		F15DD1D72B0C8C7E00984E6D /* NotifyRemoveToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15DD1D62B0C8C7E00984E6D /* NotifyRemoveToastView.swift */; };
 		F15DD1DC2B0C96E700984E6D /* RelatedFoodModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15DD1DB2B0C96E700984E6D /* RelatedFoodModalViewController.swift */; };
@@ -224,6 +226,8 @@
 		3FE6C3722B14CE0A00209599 /* OrderModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderModel.swift; sourceTree = "<group>"; };
 		3FE6C3742B15007000209599 /* CartAddressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartAddressView.swift; sourceTree = "<group>"; };
 		3FE6C3762B15C53A00209599 /* AllSelectedItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllSelectedItemView.swift; sourceTree = "<group>"; };
+		3FE6C37C2B175A9A00209599 /* CartResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartResponse.swift; sourceTree = "<group>"; };
+		3FE6C37E2B175AB800209599 /* CartCheckService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartCheckService.swift; sourceTree = "<group>"; };
 		F15DD1D42B0C8C6600984E6D /* NotifyAddToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifyAddToastView.swift; sourceTree = "<group>"; };
 		F15DD1D62B0C8C7E00984E6D /* NotifyRemoveToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifyRemoveToastView.swift; sourceTree = "<group>"; };
 		F15DD1DB2B0C96E700984E6D /* RelatedFoodModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelatedFoodModalViewController.swift; sourceTree = "<group>"; };
@@ -263,6 +267,7 @@
 			isa = PBXGroup;
 			children = (
 				092DC5612B14F86F008746A6 /* ProductResponse.swift */,
+				3FE6C37C2B175A9A00209599 /* CartResponse.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -640,6 +645,7 @@
 				092DC55E2B14F829008746A6 /* ProductService.swift */,
 				092DC5632B14F9E7008746A6 /* KingfisherService.swift */,
 				092DC5702B15B81E008746A6 /* CartService.swift */,
+				3FE6C37E2B175AB800209599 /* CartCheckService.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -956,6 +962,7 @@
 				092DC5552B14F550008746A6 /* NetworkError.swift in Sources */,
 				3FE4CCEC2B10C4D7009C9029 /* CompletedOrderView.swift in Sources */,
 				3FE6C3712B14333B00209599 /* CartModel.swift in Sources */,
+				3FE6C37F2B175AB800209599 /* CartCheckService.swift in Sources */,
 				09BA86BB2B0A6F0E00BF85D9 /* BottomCTAButton.swift in Sources */,
 				095AB57A2B11AD9000DA246F /* AlertBuilder.swift in Sources */,
 				174713732B0FDAFC00E8EC51 /* DetailBottomBarView.swift in Sources */,
@@ -964,6 +971,7 @@
 				17A870A72B08657500D5162C /* Font.swift in Sources */,
 				F15DD1DE2B0C970700984E6D /* RelatedFoodModalView.swift in Sources */,
 				09BA86AD2B0A4C9200BF85D9 /* TabBarView.swift in Sources */,
+				3FE6C37D2B175A9A00209599 /* CartResponse.swift in Sources */,
 				092DC5532B14F536008746A6 /* HTTPMethod.swift in Sources */,
 				09BA86B32B0A4E4D00BF85D9 /* UICollectionView+.swift in Sources */,
 				3FE4CCF02B11024D009C9029 /* BenefitsInfoView.swift in Sources */,

--- a/Kurly/Kurly/Network/DTO/CartResponse.swift
+++ b/Kurly/Kurly/Network/DTO/CartResponse.swift
@@ -1,0 +1,17 @@
+//
+//  CartResponse.swift
+//  Kurly
+//
+//  Created by ParkJunHyuk on 2023/11/29.
+//
+
+import Foundation
+
+struct CartResponse: Response {
+    let deliveryType: String
+    let productName: String
+    let price: Int
+    let discountRate: Int
+    let imageURL: String
+    let count: Int
+}

--- a/Kurly/Kurly/Network/Service/CartCheckService.swift
+++ b/Kurly/Kurly/Network/Service/CartCheckService.swift
@@ -25,10 +25,6 @@ final class CartCheckService {
         guard let model = try await self.getCartResponse(xAuthId: xAuthId) else {
             throw NetworkError.badCasting
         }
-
-        guard let iamge = try await KingfisherService.fetchImage(with: model.imageURL) else {
-            throw NetworkError.badCasting
-        }
         
         return createCartModelData(cartData: model)
     }

--- a/Kurly/Kurly/Network/Service/CartCheckService.swift
+++ b/Kurly/Kurly/Network/Service/CartCheckService.swift
@@ -1,0 +1,46 @@
+//
+//  CartCheckService.swift
+//  Kurly
+//
+//  Created by ParkJunHyuk on 2023/11/29.
+//
+
+import Foundation
+
+final class CartCheckService {
+    
+    private let apiService: Requestable
+    
+    init(apiService: Requestable) {
+        self.apiService = apiService
+    }
+    
+    func getCartResponse(xAuthId: Int) async throws -> [CartResponse]? {
+        let urlRequest = try NetworkRequest(path: "/cart", httpMethod: .get, header: ["X-Auth-id": "\(xAuthId)"]).makeURLRequest()
+        
+        return try await apiService.request(urlRequest)
+    }
+    
+    func fetchCart(xAuthId: Int) async throws -> [CartModel] {
+        guard let model = try await self.getCartResponse(xAuthId: xAuthId) else {
+            throw NetworkError.badCasting
+        }
+
+        guard let iamge = try await KingfisherService.fetchImage(with: model.imageURL) else {
+            throw NetworkError.badCasting
+        }
+        
+        return createCartModelData(cartData: model)
+    }
+    
+    func createCartModelData(cartData: [CartResponse]) -> [CartModel] {
+        
+        var cartModelData: [CartModel] = []
+        
+        cartData.forEach { data in
+            cartModelData.append(CartModel(productName: data.productName, originalPrice: Double(data.price), discountRate: Double(data.discountRate), imageURL: data.imageURL, itemCount: data.count))
+        }
+        
+        return cartModelData
+    }
+}

--- a/Kurly/Kurly/Presentation/Cart/Cells/CartItemCollectionViewCell.swift
+++ b/Kurly/Kurly/Presentation/Cart/Cells/CartItemCollectionViewCell.swift
@@ -142,7 +142,7 @@ extension CartItemCollectionViewCell {
         self.itemDiscountPrice.text = "\(Int(model.discountedPrice).priceText)"
         self.itemPrice.text = "\(Int(model.calculatePrice).priceText)"
         self.itemPrice.attributedText = itemPrice.text?.strikeThrough()
-        print(model.imageURL)
+        
         Task {
             let image = try await KingfisherService.fetchImage(with: model.imageURL)
             

--- a/Kurly/Kurly/Presentation/Cart/Cells/CartItemCollectionViewCell.swift
+++ b/Kurly/Kurly/Presentation/Cart/Cells/CartItemCollectionViewCell.swift
@@ -135,8 +135,8 @@ final class CartItemCollectionViewCell: UICollectionViewCell, CollectionViewCell
 
 extension CartItemCollectionViewCell {
     
-    func bindModel(model: CartModel) {
-        self.itemRow = model.id
+    func bindModel(model: CartModel, row: Int) {
+        self.itemRow = row
         self.itemLabel.text = model.productName
         self.itemDiscountPrice.text = "\(Int(model.discountedPrice).priceText)"
         self.itemPrice.text = "\(Int(model.calculatePrice).priceText)"

--- a/Kurly/Kurly/Presentation/Cart/Cells/CartItemCollectionViewCell.swift
+++ b/Kurly/Kurly/Presentation/Cart/Cells/CartItemCollectionViewCell.swift
@@ -59,8 +59,9 @@ final class CartItemCollectionViewCell: UICollectionViewCell, CollectionViewCell
         }
         
         itemImageView.do {
-            $0.image = ImageLiterals.Home.img.large
+//            $0.image = ImageLiterals.Home.img.large
             $0.sizeToFit()
+            $0.contentMode = .scaleAspectFit
         }
         
         itemDiscountPrice.do {
@@ -141,6 +142,14 @@ extension CartItemCollectionViewCell {
         self.itemDiscountPrice.text = "\(Int(model.discountedPrice).priceText)"
         self.itemPrice.text = "\(Int(model.calculatePrice).priceText)"
         self.itemPrice.attributedText = itemPrice.text?.strikeThrough()
+        print(model.imageURL)
+        Task {
+            let image = try await KingfisherService.fetchImage(with: model.imageURL)
+            
+            DispatchQueue.main.async {
+                self.itemImageView.image = image
+            }
+        }
         
         self.selectItemButton.isSelected = model.isSelect
         self.stepper.value = model.itemCount

--- a/Kurly/Kurly/Presentation/Cart/Cells/OrderPriceCollectionViewCell.swift
+++ b/Kurly/Kurly/Presentation/Cart/Cells/OrderPriceCollectionViewCell.swift
@@ -168,7 +168,7 @@ extension OrderPriceCollectionViewCell {
         numberFormatter.numberStyle = .decimal
         
         self.itemPrice.text = "\(numberFormatter.string(for: model.itemPrice) ?? "0") 원"
-        self.itemDiscountPrice.text = model.discountedPrice == 0 ? "\(model.discountedPrice) 원" : "-\(numberFormatter.string(for: model.discountedPrice) ?? "0") 원"
+        self.itemDiscountPrice.text = model.discountPrice == 0 ? "\(model.discountPrice) 원" : "-\(numberFormatter.string(for: model.discountPrice) ?? "0") 원"
         self.deliveryPrice.text = "\(model.deliveryPrice) 원"
         self.orderPrice.text = "\((model.totalPrice).priceText)"
     }

--- a/Kurly/Kurly/Presentation/Cart/Model/CartModel.swift
+++ b/Kurly/Kurly/Presentation/Cart/Model/CartModel.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 struct CartModel {
-    let id: Int
     let productName: String
     var originalPrice: Double
     var discountRate: Double
@@ -34,18 +33,15 @@ struct CartModel {
 
 extension CartModel {
     static func dummy() -> [CartModel] {
-        return [CartModel(id: 0,
-                          productName: "[시골보쌈과 감자옹심이] 감자옹심이 칼국수(2인분)",
+        return [CartModel(productName: "[시골보쌈과 감자옹심이] 감자옹심이 칼국수(2인분)",
                           originalPrice: 10500,
                           discountRate: 50,
                           imageURL: "https://insopt-seminar3.s3.ap-northeast-2.amazonaws.com/marketKurly/kurly1.png", itemCount: 1),
-                CartModel(id: 1,
-                          productName: "[올면] 속초식 명태 회냉면 2인분",
+                CartModel(productName: "[올면] 속초식 명태 회냉면 2인분",
                           originalPrice: 12000,
                           discountRate: 50,
                           imageURL: "https://insopt-seminar3.s3.ap-northeast-2.amazonaws.com/marketKurly/kurly3.svg", itemCount: 1),
-                CartModel(id: 2,
-                          productName: "[광화문 미진] 메밀국수 (2인분)",
+                CartModel(productName: "[광화문 미진] 메밀국수 (2인분)",
                           originalPrice: 9980,
                           discountRate: 50,
                           imageURL: "https://insopt-seminar3.s3.ap-northeast-2.amazonaws.com/marketKurly/kurly4.svg", itemCount: 1)]

--- a/Kurly/Kurly/Presentation/Cart/Model/CartModel.swift
+++ b/Kurly/Kurly/Presentation/Cart/Model/CartModel.swift
@@ -9,13 +9,16 @@ import UIKit
 
 struct CartModel {
     let productName: String
-    var originalPrice: Double
-    var discountRate: Double
+    let originalPrice: Double
+    let discountRate: Double
     let imageURL: String
     var isSelect: Bool = false
+    var discountPrice: Int {
+        return Int(originalPrice * discountRate / 100)
+    }
+    
     var discountedPrice: Int {
-        let discountAmount = originalPrice * discountRate / 100
-        return Int(originalPrice - discountAmount) * itemCount
+        return Int(originalPrice - Double(discountPrice)) * itemCount
     }
     
     var calculatePrice: Int {

--- a/Kurly/Kurly/Presentation/Cart/Model/OrderModel.swift
+++ b/Kurly/Kurly/Presentation/Cart/Model/OrderModel.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct OrderModel {
     let itemPrice: Int
-    let discountedPrice: Int
+    let discountPrice: Int
     let deliveryPrice: Int
     let totalPrice: Int
 }

--- a/Kurly/Kurly/Presentation/Cart/ViewControllers/CartViewController.swift
+++ b/Kurly/Kurly/Presentation/Cart/ViewControllers/CartViewController.swift
@@ -23,7 +23,6 @@ final class CartViewController: BaseViewController {
     private var cartItemData: [CartModel] = [] {
         didSet {
             cartView.cartHeaderView.allSelectedItemView.bindData(seletedItemCount: selectedItem.count, AllItemCount: cartItemData.count)
-            
             cartView.cartItemCollectionView.reloadData()
         }
     }

--- a/Kurly/Kurly/Presentation/Cart/ViewControllers/CartViewController.swift
+++ b/Kurly/Kurly/Presentation/Cart/ViewControllers/CartViewController.swift
@@ -98,7 +98,7 @@ extension CartViewController {
         Task {
             do {
                 let result = try await cartCheckService.fetchCart(xAuthId: 1)
-                print("결과", result)
+
                 cartItemData = result
                 
                 if result.isEmpty {

--- a/Kurly/Kurly/Presentation/Cart/ViewControllers/CartViewController.swift
+++ b/Kurly/Kurly/Presentation/Cart/ViewControllers/CartViewController.swift
@@ -17,10 +17,11 @@ enum CartViewType {
 final class CartViewController: BaseViewController {
     
     private let cartView = CartView(type: .order)
-    private var dummy = CartModel.dummy()
+    
+    private var cartItemData: [CartModel] = []
     private var selectedItem: [CartModel] = [] {
         didSet {
-            cartView.cartHeaderView.allSelectedItemView.bindData(seletedItemCount: selectedItem.count, AllItemCount: dummy.count)
+            cartView.cartHeaderView.allSelectedItemView.bindData(seletedItemCount: selectedItem.count, AllItemCount: cartItemData.count)
             
             let result = calculateSelectedItemPrice(seletedItem: self.selectedItem)
             cartView.bindPrice(totalPrice: result.totalPrice)
@@ -81,13 +82,13 @@ extension CartViewController: SelectedItemProtocol {
     
     func getButtonState(state: Bool, row: Int) {
         if state == true {
-            dummy[row].isSelect = state
+            cartItemData[row].isSelect = state
             
-            selectedItem.append(dummy[row])
+            selectedItem.append(cartItemData[row])
         } else {
-            dummy[row].isSelect = state
+            cartItemData[row].isSelect = state
             
-            if let index = selectedItem.firstIndex(where: { $0.id == row }) {
+            if let index = selectedItem.firstIndex(where: { $0.productName == cartItemData[row].productName }) {
                 selectedItem.remove(at: index)
             }
         }
@@ -97,12 +98,12 @@ extension CartViewController: SelectedItemProtocol {
 extension CartViewController: UpdatingStepperProtocol {
     
     func updateStepperValue(value: Int, row: Int) {
-        dummy[row].itemCount = value
-        print(dummy[row])
+        cartItemData[row].itemCount = value
+        print(cartItemData[row])
         
-        if dummy[row].isSelect == true {
-            if let index = selectedItem.firstIndex(where: { $0.id == row }) {
-                selectedItem[index] = dummy[row]
+        if cartItemData[row].isSelect == true {
+            if let index = selectedItem.firstIndex(where: { $0.productName == cartItemData[row].productName }) {
+                selectedItem[index] = cartItemData[row]
             }
         } else {
             cartView.cartItemCollectionView.reloadData()
@@ -113,7 +114,7 @@ extension CartViewController: UpdatingStepperProtocol {
 extension CartViewController {
     
     private func bindModel() {
-        cartView.cartHeaderView.allSelectedItemView.bindData(seletedItemCount: selectedItem.count, AllItemCount: dummy.count)
+        cartView.cartHeaderView.allSelectedItemView.bindData(seletedItemCount: selectedItem.count, AllItemCount: cartItemData.count)
         
         cartView.bindPrice(totalPrice: 0)
     }
@@ -155,15 +156,15 @@ extension CartViewController {
         sender.isSelected.toggle()
         
         if sender.isSelected == true {
-            for i in 0..<dummy.count {
-                if dummy[i].isSelect == false {
-                    dummy[i].isSelect = true
-                    selectedItem.append(dummy[i])
+            for i in 0..<cartItemData.count {
+                if cartItemData[i].isSelect == false {
+                    cartItemData[i].isSelect = true
+                    selectedItem.append(cartItemData[i])
                 }
             }
         } else {
-            for i in 0..<dummy.count {
-                dummy[i].isSelect = false
+            for i in 0..<cartItemData.count {
+                cartItemData[i].isSelect = false
                 selectedItem.removeAll()
             }
         }
@@ -190,7 +191,7 @@ extension CartViewController: UICollectionViewDataSource {
         
         switch section {
         case 0 :
-            return dummy.count
+            return cartItemData.count
         case 1 :
             return 1
         default:
@@ -209,7 +210,7 @@ extension CartViewController: UICollectionViewDataSource {
             
             cell.deleteItemButton.addTarget(self, action: #selector(tapDeleteItemButton), for: .touchUpInside)
             
-            cell.bindModel(model: dummy[indexPath.row])
+            cell.bindModel(model: cartItemData[indexPath.row], row: indexPath.row)
             
             return cell
         case 1:

--- a/Kurly/Kurly/Presentation/Cart/Views/CartHeaderView.swift
+++ b/Kurly/Kurly/Presentation/Cart/Views/CartHeaderView.swift
@@ -12,8 +12,13 @@ import Then
 
 final class CartHeaderView: BaseView {
     
-    var cartType: CartViewType
-
+    var cartType: CartViewType {
+        didSet {
+            setUI()
+            setLayout()
+        }
+    }
+    
     let divider = UIView()
     let cartAddressView = CartAddressView()
     let allSelectedItemView = AllSelectedItemView()
@@ -22,6 +27,8 @@ final class CartHeaderView: BaseView {
     init(type: CartViewType) {
         self.cartType = type
         super.init(frame: .zero)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(handleCartTypeDidChange(_:)), name: CartView.cartTypeDidChangeNotification, object: nil)
     }
     
     required init?(coder: NSCoder) {
@@ -39,6 +46,10 @@ final class CartHeaderView: BaseView {
     }
     
     override func setLayout() {
+        
+        divider.removeFromSuperview()
+        allSelectedItemView.removeFromSuperview()
+        
         self.addSubview(cartAddressView)
         
         cartAddressView.snp.makeConstraints {
@@ -61,5 +72,17 @@ final class CartHeaderView: BaseView {
                 $0.bottom.equalToSuperview()
             }
         }
+    }
+    
+    @objc private func handleCartTypeDidChange(_ notification: Notification) {
+        if let newCartType = notification.object as? CartViewType {
+            cartType = newCartType
+        }
+    }
+
+    deinit {
+        print("CartHeaderView NotificationCenter 연결 종료")
+        
+        NotificationCenter.default.removeObserver(self, name: CartView.cartTypeDidChangeNotification, object: nil)
     }
 }

--- a/Kurly/Kurly/Presentation/Cart/Views/CartView.swift
+++ b/Kurly/Kurly/Presentation/Cart/Views/CartView.swift
@@ -134,7 +134,7 @@ extension CartView {
     func updateView(forScrollOffset yOffset: CGFloat) {
     
         let scrollyOffset = -yOffset - 175
-        print(scrollyOffset)
+
         let cartAddressViewAlpha = max((30 + scrollyOffset) / (30 - 0), 0)
         let dividerAlpha = max((10 + scrollyOffset) / (10 - 0), 0)
         

--- a/Kurly/Kurly/Presentation/Common/UIComponents/BottomCTAButton.swift
+++ b/Kurly/Kurly/Presentation/Common/UIComponents/BottomCTAButton.swift
@@ -41,7 +41,12 @@ enum BottomCTAButtonType {
 
 final class BottomCTAButton: UIButton {
     
-    var titleType: BottomCTAButtonType
+    var titleType: BottomCTAButtonType {
+        didSet{
+            setUI()
+            print("버튼 값 변경")
+        }
+    }
     
     init(type: BottomCTAButtonType) {
         self.titleType = type


### PR DESCRIPTION
## 🍧 작업한 내용

<!-- 작업하게 된 배경을 간단히 적어주세요! -->
- 장바구니 조회를 위한 `CartCheckService` & `CartResponse` 구현
- `CartViewController` 에서 데이터 변경 시 CollectionView reload 로직 구현
- 장바구니 상품 유무를 통해 `NotificationCenter` 로 보여줄 화면 로직 구현

## 🚨 참고 사항

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
-  화면이 로드 될 때 이미 초기 값으로 상품이 없을 때의 View 로 띄우도록 되어있습니다.
- 화면이 로드 되면서 상품의 데이터를 서버에서 받아오고 상품이 존재할 시 상품이 있는 화면을 띄워야만 했습니다.
- 다시 화면을 바꾸기 위해서 NotificationCenter 를 사용하여 여러 View 에서 cartType 을 관찰하여 값이 바뀌면 다시 그리도록 로직을 구성하였습니다.

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 상품이 있을 때 | <img src = "https://github.com/DO-SOPT-CDS-APP-7/Kurly-iOS/assets/45564605/aaee1e58-ba6f-438e-ae94-3d571a1c2553" width ="250">|
| 상품이 없을 때 | <img src = "https://github.com/DO-SOPT-CDS-APP-7/Kurly-iOS/assets/45564605/0513ba4a-b3ea-426b-9856-cafed27abc20" width ="250">|


## 😈 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #91 
