### PR TITLE
[Fix] #112 - 토스트 뷰 소멸 이후 View에서 제거

### DIFF
--- a/Kurly/Kurly/Presentation/Detail/ViewControllers/DetailViewController.swift
+++ b/Kurly/Kurly/Presentation/Detail/ViewControllers/DetailViewController.swift
@@ -163,6 +163,10 @@ extension DetailViewController {
                 self.notifyRemoveToastView.downToastView()
             }
         }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+            self.notifyRemoveToastView.removeFromSuperview()
+        }
     }
 }
 

--- a/Kurly/Kurly/Presentation/RelatedFoodModal/ViewControllers/RelatedFoodModalViewController.swift
+++ b/Kurly/Kurly/Presentation/RelatedFoodModal/ViewControllers/RelatedFoodModalViewController.swift
@@ -68,5 +68,9 @@ extension RelatedFoodModalViewController {
                 self.relatedFoodModalView.notifyAddToastView.downToastView()
             }
         }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+            self.relatedFoodModalView.notifyAddToastView.removeFromSuperview()
+        }
     }
 }


### PR DESCRIPTION
## 🍧 작업한 내용

<!-- 작업하게 된 배경을 간단히 적어주세요! -->
- 찜하기 버튼 클릭 이후 토스트뷰가 생성, 소멸 뒤에 아직 View 하단에 남아있었습니다.

## 🚨 참고 사항

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 찜하기 버튼 클릭 이후 토스트뷰가 소멸 뒤에 아직 View 하단에 남아있는 오류를 수정했습니다.

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/DO-SOPT-CDS-APP-7/Kurly-iOS/assets/62370742/49b2e964-b99d-4216-9501-410e003d39d6" width ="250">|

## 😈 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #112 
